### PR TITLE
Add To Awesome Alternatives in Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 * [bottom](https://github.com/ClementTsang/bottom) - Yet another cross-platform graphical process/system monitor.
 * [ytop](https://github.com/cjbassi/ytop) (no longer maintained) - A TUI system monitor written in Rust
+* [Zenith](https://github.com/bvaisvil/zenith) - A TUI with zoomable charts and a replacement for top and htop. 
 
 #### uniq
 


### PR DESCRIPTION
changelog:

Add Zenith. A htop and top replacement written in Rust with zoom-able charts